### PR TITLE
refactor: avoid file_cache warning

### DIFF
--- a/manage-cluster-state
+++ b/manage-cluster-state
@@ -220,7 +220,7 @@ class GoogleCloudProvider(CloudProvider):
         project_name = response.text
 
         credentials = oauth2client.client.GoogleCredentials.get_application_default()
-        compute = googleapiclient.discovery.build('compute', 'v1', credentials=credentials)
+        compute = googleapiclient.discovery.build('compute', 'v1', credentials=credentials, cache_discovery=False)
 
         zones = compute.zones().list(project=project_name).execute()
         instances = []


### PR DESCRIPTION
This gets rid of the warning.
```
WARNING:googleapiclient.discovery_cache:file_cache is unavailable when using oauth2client >= 4.0.0
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/googleapiclient/discovery_cache/__init__.py", line 36, in autodetect
    from google.appengine.api import memcache
ModuleNotFoundError: No module named 'google'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 33, in <module>
    from oauth2client.contrib.locked_file import LockedFile
ModuleNotFoundError: No module named 'oauth2client.contrib.locked_file'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 37, in <module>
    from oauth2client.locked_file import LockedFile
ModuleNotFoundError: No module named 'oauth2client.locked_file'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/googleapiclient/discovery_cache/__init__.py", line 41, in autodetect
    from . import file_cache
  File "/usr/local/lib/python3.6/site-packages/googleapiclient/discovery_cache/file_cache.py", line 41, in <module>
    'file_cache is unavailable when using oauth2client >= 4.0.0')
ImportError: file_cache is unavailable when using oauth2client >= 4.0.0
```
As the warning says, we are not losing functionality by setting `cache_discovery` to False as it is not available. 