### PR TITLE
fix: add oauth2client requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3
 google-api-python-client
+oauth2client==4.1.2
 python-novaclient
 requests


### PR DESCRIPTION
oauth2client is not a dependency of google-api-python-client so has to
be added explicitly.